### PR TITLE
Changed alien initialization

### DIFF
--- a/AlienInterfaces/src/alieninterfaces/Alien.java
+++ b/AlienInterfaces/src/alieninterfaces/Alien.java
@@ -11,7 +11,8 @@ package alieninterfaces;
  */
 public interface Alien
 {
-    MoveDir getMove(Context api);
-    Action getAction(Context api);
-    void processResults(Context api); 
+    void init(Context ctx);
+    MoveDir getMove();
+    Action getAction();
+    void processResults(); 
 }

--- a/ConsoleAliensGame/nbproject/private/private.xml
+++ b/ConsoleAliensGame/nbproject/private/private.xml
@@ -4,12 +4,11 @@
     <open-files xmlns="http://www.netbeans.org/ns/projectui-open-files/2">
         <group>
             <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/SpaceGrid.java</file>
-            <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/ViewImplementation.java</file>
             <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/AlienAPI.java</file>
             <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/AlienContainer.java</file>
             <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/GameSpace.java</file>
-            <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/JARLoader.java</file>
             <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/ConsoleAliensGame.java</file>
+            <file>file:/C:/Users/gmein/OneDrive%20-%20Eastside%20Preparatory%20School/Programming%202%20-%20Introduction%20to%20Java/AliensGame/ConsoleAliensGame/src/consolealiensgame/JARLoader.java</file>
         </group>
     </open-files>
 </project-private>

--- a/ConsoleAliensGame/src/consolealiensgame/AlienContainer.java
+++ b/ConsoleAliensGame/src/consolealiensgame/AlienContainer.java
@@ -6,12 +6,17 @@
 package consolealiensgame;
 
 import alieninterfaces.*;
+import java.lang.reflect.Constructor;
+
 
 /**
  *
  * @author guberti
  */
 public class AlienContainer {
+    public final String alienPackageName;
+    public final String alienClassName;
+    public final Constructor<?> alienConstructor;
     private final Alien alien;
     private final AlienAPI api;
     
@@ -24,18 +29,39 @@ public class AlienContainer {
     
     // Declare stats here
     
-    public AlienContainer(int x, int y, Alien alien, int energy, int tech) {
-        this.alien = alien;
+    
+    //
+    // Heads up: This constructs an AlienContainer and contained Alien
+    //
+    public AlienContainer(int x, int y, String alienPackageName, String alienClassName, Constructor<?> cns, int energy, int tech) {
+        Alien a;
+        
+        this.alienPackageName = alienPackageName;
+        this.alienClassName = alienClassName;
+        this.alienConstructor = cns;
         this.energy = energy;
         this.tech = tech;
         this.api = new AlienAPI(this);
         
+        // construct and initialize alien
+        
+        try
+        {
+            a = (Alien) cns.newInstance();
+            a.init(this.api);
+        } catch (Throwable t)
+        {
+            a = null;
+            t.printStackTrace();
+        }
+        
+        this.alien = a;
     }
     
     public void move(ViewImplementation view) throws NotEnoughTechException {
         // Whether the move goes off the board will be determined by the grid
         api.view = view;
-        MoveDir direction = alien.getMove(api);
+        MoveDir direction = alien.getMove();
         checkMove(direction); // Throws an exception if illegal
         x += direction.x();
         y += direction.y();
@@ -47,7 +73,7 @@ public class AlienContainer {
     
     public Action getAction(ViewImplementation view) throws NotEnoughEnergyException, UnknownActionException {
         api.view = view;
-        Action action = alien.getAction(api);
+        Action action = alien.getAction();
         switch (action.code) {
             case None: 
             case Gain:

--- a/ConsoleAliensGame/src/consolealiensgame/ConsoleAliensGame.java
+++ b/ConsoleAliensGame/src/consolealiensgame/ConsoleAliensGame.java
@@ -20,12 +20,11 @@ public class ConsoleAliensGame {
      */
     public static void main(String[] args) {
         SpaceGrid grid = new SpaceGrid();
-        grid.addAlien(2, 2, new Martian());
         
         try
         {
             Constructor<?> cs = JARLoader.Load("stockaliens", "Dalek");
-            Alien a = (Alien) cs.newInstance();
+            grid.addAlien(2, 2, "stockaliens", "Dalek", cs);
         } catch (Throwable t)
         {
             t.printStackTrace();

--- a/ConsoleAliensGame/src/consolealiensgame/SpaceGrid.java
+++ b/ConsoleAliensGame/src/consolealiensgame/SpaceGrid.java
@@ -8,6 +8,7 @@ package consolealiensgame;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.lang.reflect.Constructor;
 import alieninterfaces.*;
 
 /**
@@ -145,7 +146,10 @@ public class SpaceGrid {
                     aliens.add(new AlienContainer(
                         aliens.get(i).x, 
                         aliens.get(i).y,
-                        /*alien */ null, actions[i].power, 1));
+                        aliens.get(i).alienPackageName,
+                        aliens.get(i).alienClassName,
+                        aliens.get(i).alienConstructor,
+                        actions[i].power, 1));
             }
         }
     }
@@ -184,8 +188,8 @@ public class SpaceGrid {
         return max;
     }
     
-    void addAlien(int x, int y, Alien alien) {
-        AlienContainer aC = new AlienContainer(x, y, alien, 1, 1);
+    void addAlien(int x, int y, String alienPackageName, String alienClassName, Constructor<?> cns) {
+        AlienContainer aC = new AlienContainer(x, y, alienPackageName, alienClassName, cns, 1, 1);
         aliens.add(aC);
     }
     

--- a/StockAliens/src/stockaliens/Dalek.java
+++ b/StockAliens/src/stockaliens/Dalek.java
@@ -15,25 +15,34 @@ import java.util.Random;
 public class Dalek implements Alien {
 
     Random rand;
+    Context ctx;
+    
     final boolean debug = true;
     
     
     
 
     public Dalek() {
+    }
+    
+    public void init(Context game_ctx) {
         rand = new Random();
+        ctx = game_ctx;
+        ctx.debugOut("Dalek initialized");
+
+        
     }
 
     // Martians move left, right, left, right
-    public MoveDir getMove(Context api) {
+    public MoveDir getMove() {
         
-        api.debugOut("Dalek Move requested");
+        ctx.debugOut("Dalek Move requested");
         
         
         int move_energy;
 
         // don't move more than you have tech
-        move_energy = Math.min(api.getEnergy(), api.getTech());
+        move_energy = Math.min(ctx.getEnergy(), ctx.getTech());
         // don't move more than 5, leave energy for other stuff
         move_energy = Math.min(move_energy, 5);
 
@@ -45,31 +54,31 @@ public class Dalek implements Alien {
         int y = move_energy;
 
         // don't move off the board
-        x = Math.min(api.getX(), x);
-        y = Math.min(api.getY(), y);
+        x = Math.min(ctx.getX(), x);
+        y = Math.min(ctx.getY(), y);
 
         return new MoveDir(x, y);
     }
 
-    public Action getAction(Context api) {
+    public Action getAction() {
         
-        api.debugOut("Dalek Action requested");
+        ctx.debugOut("Dalek Action requested");
         
-        View view = api.getView();
+        View view = ctx.getView();
 
         
         // catch and shenanigans
         try {
             // is there another alien on our position?
-            if (view.isAlienAtPos(api.getX(), api.getY())) {
+            if (view.isAlienAtPos(ctx.getX(), ctx.getY())) {
                 // if so, do we have any energy?
-                if (api.getEnergy() < 3) {
+                if (ctx.getEnergy() < 3) {
                     // no, lie still and start praying
                     return new Action(ActionCode.Gain);
                 }
 
                 // or, spend our energy on fighting
-                return new Action(ActionCode.Fight, api.getEnergy() - 2);
+                return new Action(ActionCode.Fight, ctx.getEnergy() - 2);
             }
         } catch (Exception e) {
             // do something here to deal with errors
@@ -78,14 +87,14 @@ public class Dalek implements Alien {
         //
         // if we have spare energy, research tech
         //
-        if (api.getEnergy() > (api.getTech() + 2)) {
+        if (ctx.getEnergy() > (ctx.getTech() + 2)) {
             return new Action(ActionCode.Research);
         }
         return new Action(ActionCode.Gain);
     }
 
-    public void processResults(Context api) {
-        api.debugOut("Dalek processing results");
+    public void processResults() {
+        ctx.debugOut("Dalek processing results");
         return;
     }
 

--- a/StockAliens/src/stockaliens/Martian.java
+++ b/StockAliens/src/stockaliens/Martian.java
@@ -11,23 +11,25 @@ import alieninterfaces.*;
  */
 public class Martian implements Alien {
     int currentDir;
+    Context ctx;
     
-    public Martian() {
+    public void init(Context ctx) {
         currentDir = 1;
+        this.ctx = ctx;
     }
     
     // Martians move left, right, left, right
-    public MoveDir getMove(Context api) {
+    public MoveDir getMove() {
         currentDir *= -1;
         return new MoveDir(currentDir, 0);
     }
 
     
-    public Action getAction(Context api) {
+    public Action getAction() {
         return new Action(ActionCode.Gain);
     }
     
-    public void processResults(Context api) {
+    public void processResults() {
         return;
     }
 }

--- a/StockAliens/src/stockaliens/Venusian.java
+++ b/StockAliens/src/stockaliens/Venusian.java
@@ -12,14 +12,16 @@ import alieninterfaces.*;
 public class Venusian implements Alien {
     int currentDirX;
     int currentDirY;
-    public Venusian() {
+    Context ctx;
+    
+    public void init(Context ctx) {
         currentDirX = 0;
         currentDirY = 0;
-        
+        this.ctx = ctx;
     }
     
     // Move Function
-    public MoveDir getMove(Context api) {
+    public MoveDir getMove() {
         
         return new MoveDir(currentDirX, currentDirY);
     }
@@ -34,11 +36,11 @@ public class Venusian implements Alien {
         return Math.min(api.energy(), api.tech()) / 2;
     }*/
     
-    public Action getAction(Context api) {
+    public Action getAction() {
         return new Action(ActionCode.Gain);
     }
     
-    public void processResults(Context api) {
+    public void processResults() {
         return;
     }
 


### PR DESCRIPTION
Changed Alien interface to include init() method. New convention is that alien constructors have no parameters, and are not supposed to do any
work. Work that could fail should happen in init(). init() also received a context interface (api) that the alien holds on to, so we don't have
to pass it in subsequent Alien calls.

As part of this, had to change AlienContainer so that it is the one that cause the dynamic construction of the Alien. if receives a constructor from the SpaceGrid, along with diagnostic info like package name and
class name.
